### PR TITLE
Starting a non-active span when an active span is detected.

### DIFF
--- a/lib/protobuf/rpc/extensions/client.rb
+++ b/lib/protobuf/rpc/extensions/client.rb
@@ -3,15 +3,10 @@ module Protobuf
     module Extensions
       module Client
         def send_request
-          return super if already_tracing_rpc?
           span = start_span
           results = super
           span.finish
           results
-        end
-
-        def already_tracing_rpc?
-          ::OpenTracing.active_span && ::OpenTracing.active_span.operation_name == operation_name
         end
 
         def operation_name

--- a/lib/protobuf/rpc/extensions/client.rb
+++ b/lib/protobuf/rpc/extensions/client.rb
@@ -3,9 +3,26 @@ module Protobuf
     module Extensions
       module Client
         def send_request
-          operation = "#{options[:service]}##{options[:method]}"
-          ::OpenTracing.start_active_span(operation) do
-            super
+          return super if already_tracing_rpc?
+          span = start_span
+          results = super
+          span.finish
+          results
+        end
+
+        def already_tracing_rpc?
+          ::OpenTracing.active_span && ::OpenTracing.active_span.operation_name == operation_name
+        end
+
+        def operation_name
+          @operation_name ||= "#{options[:service]}##{options[:method]}"
+        end
+
+        def start_span
+          if ::OpenTracing.active_span
+            ::OpenTracing.start_span(operation_name)
+          else
+            ::OpenTracing.start_active_span(operation_name).span
           end
         end
       end

--- a/protobuf-opentracing.gemspec
+++ b/protobuf-opentracing.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "jaeger-client"
   spec.add_development_dependency "mad_rubocop"
+  spec.add_development_dependency "opentracing_test_tracer"
   spec.add_development_dependency "protobuf", "~> 3.10.0"
   spec.add_development_dependency "protobuf-nats"
   spec.add_development_dependency "pry"

--- a/spec/protobuf/rpc/extensions/client_spec.rb
+++ b/spec/protobuf/rpc/extensions/client_spec.rb
@@ -41,18 +41,5 @@ RSpec.describe Protobuf::Opentracing::Extensions::Client do
         end
       end
     end
-
-    it "does not start a span when the active span is for the same operation" do
-      ::OpenTracing.start_active_span("TestService#test_search") do
-        client.test_search(::TestRequest.new) do |c|
-          c.on_complete do |_|
-            # Two spans: First started by the client and the second started by
-            # the server.
-            expect(::OpenTracing.global_tracer.spans.size).to be 2
-            expect(::OpenTracing.active_span.operation_name).to eq "TestService#test_search"
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/protobuf/rpc/extensions/client_spec.rb
+++ b/spec/protobuf/rpc/extensions/client_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Protobuf::Opentracing::Extensions::Client do
       ::OpenTracing.start_active_span("testing") do
         client.test_search(::TestRequest.new) do |c|
           c.on_complete do |_|
+            # Three spans: First one is the one we started in this test, second
+            # is the one started by the client, and the third is the one
+            # started by the server.
+            expect(::OpenTracing.global_tracer.spans.size).to be 3
             expect(::OpenTracing.active_span.operation_name).to eq "testing"
           end
         end
@@ -42,8 +46,10 @@ RSpec.describe Protobuf::Opentracing::Extensions::Client do
       ::OpenTracing.start_active_span("TestService#test_search") do
         client.test_search(::TestRequest.new) do |c|
           c.on_complete do |_|
-            # Two spans, one started by the client and the second by the server.
+            # Two spans: First started by the client and the second started by
+            # the server.
             expect(::OpenTracing.global_tracer.spans.size).to be 2
+            expect(::OpenTracing.active_span.operation_name).to eq "TestService#test_search"
           end
         end
       end

--- a/spec/protobuf/rpc/extensions/client_spec.rb
+++ b/spec/protobuf/rpc/extensions/client_spec.rb
@@ -1,21 +1,16 @@
 RSpec.describe Protobuf::Opentracing::Extensions::Client do
-  server = nil
-
   before do
     ::OpenTracing.global_tracer = ::OpenTracingTestTracer.build
-  end
-
-  before(:all) do
-    server = ::Protobuf::Nats::Server.new(:threads => 1)
     server.subscribe
   end
 
-  after(:all) do
+  after do
     ::OpenTracing.global_tracer = ::OpenTracing::Tracer.new
     server.unsubscribe
     server.nats.close
   end
 
+  let(:server) { ::Protobuf::Nats::Server.new(:threads => 1) }
   let(:client) { ::Protobuf::Rpc::Client.new(:service => TestService, :method => "test_search") }
 
   describe "#operation_name" do

--- a/spec/protobuf/rpc/extensions/client_spec.rb
+++ b/spec/protobuf/rpc/extensions/client_spec.rb
@@ -1,7 +1,57 @@
 RSpec.describe Protobuf::Opentracing::Extensions::Client do
-  it "starts a new active span when making a request" do
-    expect(::OpenTracing).to receive(:start_active_span).with("TestService#test_search")
-    client = ::Protobuf::Rpc::Client.new(:service => TestService)
-    client.test_search(::TestRequest.new)
+  server = nil
+
+  before do
+    ::OpenTracing.global_tracer = ::OpenTracingTestTracer.build
+  end
+
+  before(:all) do
+    server = ::Protobuf::Nats::Server.new(:threads => 1)
+    server.subscribe
+  end
+
+  after(:all) do
+    ::OpenTracing.global_tracer = ::OpenTracing::Tracer.new
+    server.unsubscribe
+    server.nats.close
+  end
+
+  let(:client) { ::Protobuf::Rpc::Client.new(:service => TestService, :method => "test_search") }
+
+  describe "#operation_name" do
+    it "uses the service name and request method for the operation name" do
+      expect(client.operation_name).to eq "TestService\#test_search"
+    end
+  end
+
+  describe "#send_request" do
+    it "starts a new active span when making a request" do
+      client.test_search(::TestRequest.new) do |c|
+        c.on_complete do |_|
+          expect(::OpenTracing.active_span.operation_name).to eq client.operation_name
+        end
+      end
+    end
+
+    it "does not start a new active span when one has already been created" do
+      ::OpenTracing.start_active_span("testing") do
+        client.test_search(::TestRequest.new) do |c|
+          c.on_complete do |_|
+            expect(::OpenTracing.active_span.operation_name).to eq "testing"
+          end
+        end
+      end
+    end
+
+    it "does not start a span when the active span is for the same operation" do
+      ::OpenTracing.start_active_span("TestService#test_search") do
+        client.test_search(::TestRequest.new) do |c|
+          c.on_complete do |_|
+            # Two spans, one started by the client and the second by the server.
+            expect(::OpenTracing.global_tracer.spans.size).to be 2
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "jaeger/client"
 require "protobuf"
 require "protobuf/nats"
 require "protobuf/opentracing"
+require "opentracing_test_tracer"
 
 require "test_service"
 


### PR DESCRIPTION
Fixes an issue where a top-level span scope would be closed and raise and exception due to an active child span was still running.

~Also checks for the active span operation name, and when it is the same as the coming operation name, no span is initiated.~

cc @ETetzlaff, @film42