### PR TITLE
Linking spans in the expected hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Or install it yourself as:
 
 ## Usage
 
-When laoded, this gem injects middleware into the RPC client flow which will
-decode tracing information and start a new active span. See the
+When loaded, this gem injects itself into the RPC server and client flow to
+include and handle tracing information on requests. See the
 [`opentracing`](https://rubygems.org/gems/opentracing/) gem for additional
 information.
 

--- a/lib/protobuf/rpc/extensions/base.rb
+++ b/lib/protobuf/rpc/extensions/base.rb
@@ -3,10 +3,10 @@ module Protobuf
     module Extensions
       module Base
         def request_fields
-          return super if options[:span].nil?
+          return super if options[:tracing_span].nil?
 
           trace_carrier = {}
-          ::OpenTracing.inject(options[:span].context,
+          ::OpenTracing.inject(options[:tracing_span].context,
                                ::OpenTracing::FORMAT_TEXT_MAP,
                                trace_carrier)
 

--- a/lib/protobuf/rpc/extensions/base.rb
+++ b/lib/protobuf/rpc/extensions/base.rb
@@ -3,10 +3,10 @@ module Protobuf
     module Extensions
       module Base
         def request_fields
-          return super if ::OpenTracing.active_span.nil?
+          return super if options[:span].nil?
 
           trace_carrier = {}
-          ::OpenTracing.inject(::OpenTracing.active_span.context,
+          ::OpenTracing.inject(options[:span].context,
                                ::OpenTracing::FORMAT_TEXT_MAP,
                                trace_carrier)
 

--- a/lib/protobuf/rpc/extensions/client.rb
+++ b/lib/protobuf/rpc/extensions/client.rb
@@ -4,6 +4,7 @@ module Protobuf
       module Client
         def send_request
           span = start_span
+          options[:span] = span
           results = super
           span.finish
           results

--- a/lib/protobuf/rpc/extensions/client.rb
+++ b/lib/protobuf/rpc/extensions/client.rb
@@ -4,7 +4,7 @@ module Protobuf
       module Client
         def send_request
           span = start_span
-          options[:span] = span
+          options[:tracing_span] = span
           results = super
           span.finish
           results

--- a/spec/protobuf/rpc/extensions/base_spec.rb
+++ b/spec/protobuf/rpc/extensions/base_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Protobuf::Opentracing::Extensions::Base do
     client.test_search(::TestRequest.new) do |c|
       c.on_complete do |conn|
         carrier = {}
-        ::OpenTracing.inject(::OpenTracing.active_span.context,
+        ::OpenTracing.inject(c.connector.options[:span].context,
                              ::OpenTracing::FORMAT_TEXT_MAP,
                              carrier)
 
@@ -36,12 +36,12 @@ RSpec.describe Protobuf::Opentracing::Extensions::Base do
     expect(cb_called).to be true
   end
 
-  it "starts an active span on the server that is a child of the client span" do
+  it "starts a span on the server that is a child of the client span" do
     cb_called = false
 
     client.test_search(::TestRequest.new) do |c|
       c.on_success do |ret|
-        expect(::OpenTracing.active_span.context.span_id.to_s).to eq(ret.parent_span_id)
+        expect(c.connector.options[:span].context.span_id.to_s).to eq(ret.parent_span_id)
         cb_called = true
       end
     end

--- a/spec/protobuf/rpc/extensions/base_spec.rb
+++ b/spec/protobuf/rpc/extensions/base_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Protobuf::Opentracing::Extensions::Base do
     client.test_search(::TestRequest.new) do |c|
       c.on_complete do |conn|
         carrier = {}
-        ::OpenTracing.inject(c.connector.options[:span].context,
+        ::OpenTracing.inject(c.connector.options[:tracing_span].context,
                              ::OpenTracing::FORMAT_TEXT_MAP,
                              carrier)
 
@@ -41,7 +41,7 @@ RSpec.describe Protobuf::Opentracing::Extensions::Base do
 
     client.test_search(::TestRequest.new) do |c|
       c.on_success do |ret|
-        expect(c.connector.options[:span].context.span_id.to_s).to eq(ret.parent_span_id)
+        expect(c.connector.options[:tracing_span].context.span_id.to_s).to eq(ret.parent_span_id)
         cb_called = true
       end
     end


### PR DESCRIPTION
Passing along tracing context not of the active span but of the span we create when making a request.

Notice how "Batcave Atlas::Amigo::UserService#search" span and "amigo_go atlas.amigo.UserService#Search" span are siblings in this trace:

![image](https://user-images.githubusercontent.com/601509/57094617-359c2880-6cce-11e9-89d9-6477d3c59c1a.png)

With this fix they will show up as parent/child:

![image](https://user-images.githubusercontent.com/601509/57094650-4a78bc00-6cce-11e9-806b-65a2b713de73.png)

@ETetzlaff, @film42